### PR TITLE
Fix following error in psutil.Process.cpu_percent method:

### DIFF
--- a/amplify/agent/util/ps.py
+++ b/amplify/agent/util/ps.py
@@ -35,7 +35,7 @@ class Process(psutil.Process):
         blocking = interval is not None and interval > 0.0
         num_cpus = psutil.cpu_count()
 
-        if psutil._POSIX:
+        if hasattr(psutil, '_POSIX') and psutil._POSIX:
             def timer():
                 return psutil._timer() * num_cpus
         else:


### PR DESCRIPTION
2016-04-01 13:44:39,299 [12628] nginx_metrics failed to collect metrics workers_cpu due to AttributeError
2016-04-01 13:44:39,299 [12628] nginx_metrics additional info:
Traceback (most recent call last):
  File "/usr/local/src/nginx-amplify/nginx-amplify-agent/amplify/agent/containers/nginx/collectors/metrics.py", line 49, in collect
    method()
  File "/usr/local/src/nginx-amplify/nginx-amplify-agent/amplify/agent/containers/nginx/collectors/metrics.py", line 182, in workers_cpu
    u, s = p.cpu_percent()
  File "/usr/local/src/nginx-amplify/nginx-amplify-agent/amplify/agent/util/ps.py", line 38, in cpu_percent
    if psutil._POSIX:
AttributeError: 'module' object has no attribute '_POSIX'
