### PR TITLE
Added useful debug information when checking nginx launcher

### DIFF
--- a/amplify/agent/managers/nginx.py
+++ b/amplify/agent/managers/nginx.py
@@ -211,6 +211,7 @@ class NginxManager(ObjectManager):
                         out, err = subp.call('ps o command %d' % ppid)
                         parent_command = out[1] # take the second line because the first is a header
                         if not any(launcher in parent_command for launcher in LAUNCHERS):
+                            context.log.debug('nginx launcher found, "%s" is currently not supported' % parent_command)
                             continue
 
                     # get path to binary, prefix and conf_path


### PR DESCRIPTION
Added useful debug information when nginx is started with a launcher that is currently not supported by nginx amplify.

You can change the wording if you prefer something else.

Prints out in amplify agent.log (with debug on):
`2016-07-20 18:53:18,xxx [xxxxx] supervisor nginx launcher found, "runsv nginx" is currently not supported`
