### PR TITLE
workaround fix for nginx exclude

### DIFF
--- a/packages/install.sh
+++ b/packages/install.sh
@@ -409,7 +409,11 @@ case "$os" in
 
 	# Install package
 	update_cmd="yum ${assume_yes} makecache"
-	install_cmd="yum ${assume_yes} install"
+	if [[ "$(grep -w nginx /etc/yum.conf)" ]]; then
+  	    install_cmd="yum ${assume_yes} install --disableexcludes=main"
+	else
+  	    install_cmd="yum ${assume_yes} install"
+	fi
 
 	install_deb_or_rpm
 	;;


### PR DESCRIPTION
On custom LEMP stacks some folks source install Nginx and exclude nginx package via /etc/yum.conf but this prevents nginx-amplify-agent from installing as it matches the exclude = nginx.

Simple change in install.sh can be made to check for this https://community.centminmod.com/threads/nginx-amplify-open-source-monitoring-service.4963/page-4#post-50859 when nginx listed in exclude line

    grep -w nginx /etc/yum.conf
    exclude=*.i386 *.i586 *.i686 nginx* php* mysql*

change line 412 of install.sh as at 14/06/17 to

```
if [[ "$(grep -w nginx /etc/yum.conf)" ]]; then
  install_cmd="yum ${assume_yes} install --disableexcludes=main"
else
  install_cmd="yum ${assume_yes} install"
fi
```

previously mentioned at https://github.com/nginxinc/nginx-amplify-agent/issues/8