### PR TITLE
fix sysvinit script being unable to stop daemon in Debian Buster

### DIFF
--- a/etc/init.d/amplify-agent
+++ b/etc/init.d/amplify-agent
@@ -71,7 +71,7 @@ do_start()
 
 do_stop()
 {
-    start-stop-daemon --stop --quiet --oknodo --retry=TERM/30/KILL/5 --pidfile $PIDFILE
+    start-stop-daemon --stop --quiet --oknodo --retry=TERM/30/KILL/5 --pidfile $PIDFILE --user $USER
     RETVAL="$?"
     rm -f $PIDFILE
     return "$RETVAL"


### PR DESCRIPTION
Since version 1.19.3, start-stop-daemon refuses to operate on pidfile
if "--pidfile" is the only specifier and pidfile owner doesn't match
real user ID of "start-stop-daemon" process.

However, action "stop" ("do_stop" routine) calls start-stop-daemon
against pidfile owned by non-root user (which is fine).

Corresponding commit in upstream:

    From bc9736f6feae7625cc5ec063ea1b27d51a5f9317 Mon Sep 17 00:00:00 2001
    From: Guillem Jover <guillem@debian.org>
    Date: Sat, 22 Sep 2018 12:12:05 +0200
    Subject: s-s-d: Check whether standalone --pidfile use is secure

    If we are only matching on the pidfile, which is owned by a non-root
    user, and we are running as a root user then this is a security risk,
    and the contents cannot be trusted, because the daemon might have been
    compromised which would allow modifying the pid within.

    If we are then calling start-stop-daemon as a privileged user, that
    would allow acting on any PID in the system.

    Prompted-by: Michael Orlitzky <michael@orlitzky.com>
    Ref: https://redmine.kannel.org/issues/771

Nota bene:
    Debian "Stretch" release (and it's derivatives) are fine since
    dpkg is from 1.18.x branch (though, this change may be backported,
    or the one may decide to install more recent version of dpkg).
    Upcoming Debian "Buster" release will have dpkg from 1.19.x branch:
    version 1.19.7 is in "testing" suite (which is in code freeze).

Solution:
    specify user in "do_stop" routine via "--user" option.

Before fix:

    # service amplify-agent status
    [ ok ] amplify-agent is running.
    # cat /run/amplify-agent/amplify-agent.pid
    9227
    # ps -p 9227
      PID TTY          TIME CMD
     9227 ?        00:00:03 amplify-agent

    # service amplify-agent stop

    # service amplify-agent status
    [FAIL] amplify-agent is not running ... failed!
    start-stop-daemon: matching only on non-root pidfile /var/run/amplify-agent/amplify-agent.pid is insecure
    # cat /run/amplify-agent/amplify-agent.pid
    cat: /run/amplify-agent/amplify-agent.pid: No such file or directory
    # ps -p 9227
      PID TTY          TIME CMD
     9227 ?        00:00:03 amplify-agent

After fix:

    # service amplify-agent status
    [ ok ] amplify-agent is running.
    # cat /run/amplify-agent/amplify-agent.pid
    31709
    # ps -p 31709
      PID TTY          TIME CMD
    31709 ?        00:00:10 amplify-agent

    # service amplify-agent stop

    # service amplify-agent status
    [FAIL] amplify-agent is not running ... failed!
    # cat /run/amplify-agent/amplify-agent.pid
    cat: /run/amplify-agent/amplify-agent.pid: No such file or directory
    # ps -p 31709
      PID TTY          TIME CMD

Signed-off-by: Konstantin Demin <rockdrilla@gmail.com>