### PR TITLE
Force pip version to 2.7

### DIFF
--- a/packages/install-source.sh
+++ b/packages/install-source.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-pip_url="https://bootstrap.pypa.io/get-pip.py"
+#pip_url="https://bootstrap.pypa.io/get-pip.py"
+pip_url="https://bootstrap.pypa.io/pip/2.7/get-pip.py"
 agent_url="https://github.com/nginxinc/nginx-amplify-agent"
 agent_conf_path="/etc/amplify-agent"
 agent_conf_file="${agent_conf_path}/agent.conf"

--- a/packages/install-source.sh
+++ b/packages/install-source.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-#pip_url="https://bootstrap.pypa.io/get-pip.py"
 pip_url="https://bootstrap.pypa.io/pip/2.7/get-pip.py"
 agent_url="https://github.com/nginxinc/nginx-amplify-agent"
 agent_conf_path="/etc/amplify-agent"


### PR DESCRIPTION
Since installer works doesn't work with python 3 yet
But pip version is now default to python 3

We need to force pip to switch to 2.7