### PR TITLE
packages: added support for Rocky Linux to install script

### DIFF
--- a/packages/install.sh
+++ b/packages/install.sh
@@ -48,6 +48,9 @@ get_os_name () {
         elif cat /etc/*-release | grep '^ID="almalinux"' > /dev/null 2>&1; then
             os="centos"
             centos_flavor="almalinux"
+        elif cat /etc/*-release | grep '^ID="rocky"' > /dev/null 2>&1; then
+            os="centos"
+            centos_flavor="rocky"
         else
             os=`cat /etc/*-release | grep '^ID=' | \
                 sed 's/^ID=["]*\([a-zA-Z]*\).*$/\1/' | \
@@ -79,11 +82,11 @@ get_os_name () {
                           tr '[:upper:]' '[:lower:]'`
                 ;;
             centos)
-                codename=`cat /etc/*-release | grep -i 'almalinux\|centos.*(' | \
+                codename=`cat /etc/*-release | grep -i 'almalinux\|rocky\|centos.*(' | \
                           sed 's/.*(\(.*\)).*/\1/' | head -1 | \
                           tr '[:upper:]' '[:lower:]'`
                 # For CentOS grab release
-                release=`cat /etc/*-release | grep -i 'almalinux\|centos.*[0-9]' | \
+                release=`cat /etc/*-release | grep -i 'almalinux\|rocky\|centos.*[0-9]' | \
                          sed 's/^[^0-9]*\([0-9][0-9]*\).*$/\1/' | head -1`
                 ;;
             rhel|ol)

--- a/tools/builders/deb.py
+++ b/tools/builders/deb.py
@@ -64,10 +64,18 @@ def build(bumprevision=False):
         changelog_first_line = 'nginx-amplify-agent (%s-%s~%s) %s; urgency=low' % (version, bld, codename, codename)
         change_first_line('%s/debian/changelog' % debuild_root, changelog_first_line)
 
+        if bumprevision:
+            # sed version_build
+            shell_call('sed -i.bak -e "s,self.version_build =.*,self.version_build = %d," amplify/agent/common/context.py' % bld)
+
         # create source tarball
         shell_call('cp packages/nginx-amplify-agent/setup.py ./')
         shell_call('tar -cz --transform "s,^,nginx-amplify-agent-%s/," -f %s/nginx-amplify-agent_%s.orig.tar.gz LICENSE MANIFEST.in amplify/agent amplify/ext amplify/__init__.py etc/ packages/ nginx-amplify-agent.py setup.py' % (version, pkg_root, version))
         shell_call('cd %s && tar zxf nginx-amplify-agent_%s.orig.tar.gz' % (pkg_root, version))
+
+        if bumprevision:
+            # restore original version_build
+            shell_call('mv amplify/agent/common/context.py.bak amplify/agent/common/context.py')
 
         # create deb package
         shell_call('cd %s && debuild -us -uc' % debuild_root, terminal=True)

--- a/tools/builders/rpm.py
+++ b/tools/builders/rpm.py
@@ -41,10 +41,18 @@ def build(bumprevision=False):
         os.makedirs(rpm_specs)
         os.makedirs(rpm_sources)
 
+        if bumprevision:
+            # sed version_build
+            shell_call('sed -i.bak -e "s,self.version_build =.*,self.version_build = %d," amplify/agent/common/context.py' % bld)
+
         # prepare sources
         shell_call('cp packages/nginx-amplify-agent/setup.py ./')
         shell_call('tar -cz --transform "s,^,nginx-amplify-agent-%s/," -f %s/nginx-amplify-agent-%s.tar.gz LICENSE MANIFEST.in amplify/agent amplify/ext amplify/__init__.py etc/ packages/ nginx-amplify-agent.py setup.py' % (version, rpm_sources, version))
         shell_call('cp packages/nginx-amplify-agent/rpm/nginx-amplify-agent.service %s' % rpm_sources)
+
+        if bumprevision:
+            # restore original version_build
+            shell_call('mv amplify/agent/common/context.py.bak amplify/agent/common/context.py')
 
         # prepare spec
         shell_call('cp packages/nginx-amplify-agent/rpm/nginx-amplify-agent.spec %s/' % rpm_specs)


### PR DESCRIPTION
While here, package builders were adjusted to include correct version build when auto-increment feature is used.

Closes nginxinc/nginx-amplify-agent#77, nginxinc/nginx-amplify-agent#82.