### PR TITLE
Fix TypeError in exponential_delay function when handling connection timeouts

### DIFF
--- a/amplify/agent/common/util/backoff.py
+++ b/amplify/agent/common/util/backoff.py
@@ -32,4 +32,4 @@ def exponential_delay(n):
         (EXPONENTIAL_COEFFICIENT ** n)
     period_size = min(exponential_limit, MAXIMUM_TIMEOUT)
 
-    return randint(0, period_size - 1)
+    return randint(0, int(period_size) - 1)


### PR DESCRIPTION
## Description
This PR fixes an issue where the NGINX Amplify Agent v1.8.3-1 crashes when experiencing connection timeouts to receiver.amplify.nginx.com on Ubuntu 24.04 Noble. The root cause is a TypeError in the exponential_delay function where a float value is being passed to random.randint() which requires integer arguments.

## Environment
- Ubuntu 24.04 Noble
- NGINX Amplify Agent v1.8.3-1~noble
- Python 3.12

## Issue
When a connection timeout occurs, the agent attempts to use the exponential backoff mechanism, but crashes with:
```TypeError: 'float' object cannot be interpreted as an integer```

This causes the agent to completely stop instead of properly handling the timeout and retrying later.

## Fix
The fix is a simple type conversion to ensure an integer is passed to the randint() function:
```python
# Before
return randint(0, period_size - 1)

# After
return randint(0, int(period_size) - 1)


Fixes #124