### PR TITLE
fix(pipelines/file): tolerate non-UTF-8 bytes in tailed log files

### DIFF
--- a/amplify/agent/pipelines/file.py
+++ b/amplify/agent/pipelines/file.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import time
 from os import stat
 
@@ -30,13 +29,13 @@ class FileTail(Pipeline):
     """
 
     def __init__(self, filename):
-        super(FileTail, self).__init__(name='file:%s' % filename)
+        super().__init__(name="file:%s" % filename)
         self.filename = filename
         self._fh = None
 
         # open a file and seek to the end
         if self.filename not in OFFSET_CACHE:
-            with open(self.filename, "r") as f:
+            with open(self.filename, errors="replace") as f:
                 f.seek(0, 2)
                 self._offset = OFFSET_CACHE[self.filename] = f.tell()
         else:
@@ -74,24 +73,23 @@ class FileTail(Pipeline):
         while tries < 2:  # Try twice before moving on.
             try:
                 new_inode = self._st_ino()
-            except:
+            except OSError:
                 time.sleep(0.5)
                 tries += 1
-                pass
             else:
                 break
 
         # If tries == 2 then we know we broke out of the while above manually.
         if tries == 2:
             context.log.error('could not check if file "%s" was rotated (maybe file was deleted?)' % self.filename)
-            context.log.debug('additional info:', exc_info=True)
+            context.log.debug("additional info:", exc_info=True)
             raise StopIteration
 
         # check for copytruncate
         # it will use the same file so inode will stay the same
         file_truncated = False
         if new_inode == self._inode and self.filename in OFFSET_CACHE:
-            with open(self.filename, 'r') as temp_fh:
+            with open(self.filename, errors="replace") as temp_fh:
                 temp_fh.seek(0, 2)
                 if temp_fh.tell() < OFFSET_CACHE[self.filename]:
                     # this means the file is smaller than previously cached
@@ -140,7 +138,7 @@ class FileTail(Pipeline):
                 self._update_inode()
                 self._offset = OFFSET_CACHE[self.filename] = 0
 
-            self._fh = open(self.filename, "r")
+            self._fh = open(self.filename, errors="replace")
             self._fh.seek(self._offset)
         return self._fh
 
@@ -151,4 +149,4 @@ class FileTail(Pipeline):
         line = self._fh.readline()
         if not line:
             raise StopIteration
-        return line.rstrip('\n\r')
+        return line.rstrip("\n\r")

--- a/tests/test_file_pipeline.py
+++ b/tests/test_file_pipeline.py
@@ -1,0 +1,41 @@
+"""
+Tests for the file pipeline (FileTail).
+"""
+import itertools
+import os
+import tempfile
+
+from amplify.agent.pipelines.file import FileTail, OFFSET_CACHE
+
+
+def test_filetail_tolerates_non_utf8_bytes():
+    """A non-UTF-8 byte in a tailed log file must not crash iteration.
+
+    Reproduces the production failure on hosts whose nginx error_log
+    mixes encodings (e.g. a stray 0xd0 from Cyrillic mojibake). With
+    the default codec + errors='strict', readline() raises
+    UnicodeDecodeError and the per-instance collector dies. With
+    errors='replace' the bad byte becomes U+FFFD and iteration
+    continues.
+    """
+    fd, path = tempfile.mkstemp(suffix=".log")
+    os.close(fd)
+    try:
+        with open(path, "wb") as fh:
+            fh.write(b"good line\n" + b"bad \xd0 byte\n" + b"after\n")
+
+        OFFSET_CACHE.pop(path, None)
+        tail = FileTail(path)
+        OFFSET_CACHE[path] = 0
+        tail._offset = 0
+
+        lines = list(itertools.islice(tail, 3))
+        assert len(lines) == 3
+        assert "good line" in lines[0]
+        assert "after" in lines[2]
+    finally:
+        OFFSET_CACHE.pop(path, None)
+        try:
+            os.unlink(path)
+        except OSError:
+            pass


### PR DESCRIPTION
## Problem

The `FileTail` pipeline opens log files with Python's default codec and `errors='strict'`. If the tailed file (e.g. nginx error_log on a host with mixed-encoding log entries) contains an invalid byte sequence — for example, a single `0xd0` byte left over from Cyrillic mojibake — `readline()` raises `UnicodeDecodeError` and the per-instance collector dies silently. The agent process keeps running but that file is no longer tailed until agent restart.

Observed on a CentOS host whose nginx error_log mixed encodings:

```
File "/usr/lib/python3.9/site-packages/amplify/agent/pipelines/file.py", line 151, in _get_next_line
    line = self._fh.readline()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd0 in position 785: invalid continuation byte
```

## Fix

Open each log file with `errors="replace"` so a single invalid byte becomes U+FFFD (replacement character) and iteration continues. `replace` is preferable to `ignore` because U+FFFD preserves byte offsets so the `OFFSET_CACHE` `tell()`/`seek()` math stays correct across restarts.

## Test

`tests/test_file_pipeline.py::test_filetail_tolerates_non_utf8_bytes` writes a log file with a stray 0xd0 byte and asserts `FileTail` yields all three lines instead of raising.

## Drive-by

Pre-commit (ruff) on this file flagged two pre-existing issues that I cleaned up while here:
- `UP008`: `super(FileTail, self).__init__(...)` → `super().__init__(...)`
- `E722`: bare `except:` → `except OSError:` (the only exception `stat()` raises)

Happy to split these out if preferred — but they're isolated to the same file as the fix.

## Origin

Filed against the GetPageSpeed fork (https://github.com/GetPageSpeed/nginx-amplify-agent — installed by ~thousands of GetPageSpeed customers) where this bug was diagnosed.