### PR TITLE
fix(bridge): drop accumulated metric backlog on /update/ ReadTimeout

### DIFF
--- a/amplify/agent/managers/bridge.py
+++ b/amplify/agent/managers/bridge.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 import gc
 import time
 
 from collections import deque
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ReadTimeout
 
 from amplify.agent.common.context import context
 from amplify.agent.common.cloud import HTTP503Error
@@ -22,12 +21,13 @@ class Bridge(AbstractManager):
     """
     Manager that flushes object bins and stores them in deques.  These deques are then sent to backend.
     """
-    name = 'bridge_manager'
+
+    name = "bridge_manager"
 
     def __init__(self, **kwargs):
-        if 'interval' not in kwargs:
-            kwargs['interval'] = context.app_config['cloud']['push_interval']
-        super(Bridge, self).__init__(**kwargs)
+        if "interval" not in kwargs:
+            kwargs["interval"] = context.app_config["cloud"]["push_interval"]
+        super().__init__(**kwargs)
 
         self.payload = {}
         self.first_run = True
@@ -46,7 +46,7 @@ class Bridge(AbstractManager):
         :return: dict of structure
         """
         # TODO check docker or OS around
-        tree = {'system': ['nginx']}
+        tree = {"system": ["nginx"]}
         return tree
 
     def _run(self):
@@ -54,7 +54,7 @@ class Bridge(AbstractManager):
             self.flush_all()
             gc.collect()
         except:
-            context.default_log.error('failed', exc_info=True)
+            context.default_log.error("failed", exc_info=True)
             raise
 
     def flush_metrics(self):
@@ -63,7 +63,7 @@ class Bridge(AbstractManager):
         """
         flush_data = self._flush_metrics()
         if flush_data:
-            self.payload['metrics'].append(flush_data)
+            self.payload["metrics"].append(flush_data)
         self._send_payload()
 
     def flush_all(self, force=False):
@@ -71,10 +71,10 @@ class Bridge(AbstractManager):
         Flushes all data
         """
         clients = {
-            'meta': self._flush_meta,
-            'metrics': self._flush_metrics,
-            'events': self._flush_events,
-            'configs': self._flush_configs
+            "meta": self._flush_meta,
+            "metrics": self._flush_metrics,
+            "events": self._flush_events,
+            "configs": self._flush_configs,
         }
 
         # Flush data and add to appropriate payload bucket.
@@ -82,7 +82,7 @@ class Bridge(AbstractManager):
             # If this is the first run, flush meta only to ensure object creation.
             flush_data = self._flush_meta()
             if flush_data:
-                self.payload['meta'].append(flush_data)
+                self.payload["meta"].append(flush_data)
         else:
             for client_type in self.payload.keys():
                 if client_type in clients:
@@ -92,8 +92,7 @@ class Bridge(AbstractManager):
 
         now = time.time()
         if force or (
-            now >= (self.last_http_attempt + self.interval + self.http_delay) and
-            now > context.backpressure_time
+            now >= (self.last_http_attempt + self.interval + self.http_delay) and now > context.backpressure_time
         ):
             self._send_payload()
 
@@ -102,13 +101,11 @@ class Bridge(AbstractManager):
         Sends current payload to backend
         """
         context.log.debug(
-            'modified payload; current payload stats: '
-            'meta - %s, metrics - %s, events - %s, configs - %s' % (
-                len(self.payload['meta']),
-                len(self.payload['metrics']),
-                len(self.payload['events']),
-                len(self.payload['configs'])
-            )
+            f"modified payload; current payload stats: "
+            f"meta - {len(self.payload['meta'])}, "
+            f"metrics - {len(self.payload['metrics'])}, "
+            f"events - {len(self.payload['events'])}, "
+            f"configs - {len(self.payload['configs'])}"
         )
 
         # Send payload to backend.
@@ -116,7 +113,7 @@ class Bridge(AbstractManager):
             self.last_http_attempt = time.time()
 
             self._pre_process_payload()  # Convert deques to lists for encoding
-            context.http_client.post('update/', data=self.payload)
+            context.http_client.post("update/", data=self.payload)
             context.default_log.debug(self.payload)
             self._reset_payload()  # Clear payload after successful
 
@@ -126,49 +123,51 @@ class Bridge(AbstractManager):
             if self.http_delay:
                 self.http_fail_count = 0
                 self.http_delay = 0  # Reset HTTP delay on success
-                context.log.debug('successful update, reset http delay')
+                context.log.debug("successful update, reset http delay")
         except Exception as e:
+            if isinstance(e, ReadTimeout):
+                dropped = self._collapse_metric_backlog_on_timeout()
+                if dropped:
+                    context.log.warning(
+                        f"bridge_manager dropped {dropped} accumulated metric snapshots after "
+                        f"ReadTimeout (kept most recent); link too slow for backlog"
+                    )
             self._post_process_payload()  # Convert lists to deques since send failed
 
             if isinstance(e, HTTPError) and e.response.status_code == 503:
                 backpressure_error = HTTP503Error(e)
                 context.backpressure_time = int(time.time() + backpressure_error.delay)
                 context.log.debug(
-                    'back pressure delay %s added (next talk: %s)' % (
-                        backpressure_error.delay,
-                        context.backpressure_time
-                    )
+                    f"back pressure delay {backpressure_error.delay} added (next talk: {context.backpressure_time})"
                 )
             else:
                 self.http_fail_count += 1
                 self.http_delay = exponential_delay(self.http_fail_count)
-                context.log.debug('http delay set to %s (fails: %s)' % (self.http_delay, self.http_fail_count))
+                context.log.debug(f"http delay set to {self.http_delay} (fails: {self.http_fail_count})")
 
             exception_name = e.__class__.__name__
-            context.log.error('failed to push data due to %s' % exception_name)
-            context.log.debug('additional info:', exc_info=True)
+            context.log.error(f"failed to push data due to {exception_name}")
+            context.log.debug("additional info:", exc_info=True)
 
         context.log.debug(
-            'finished flush_all; new payload stats: '
-            'meta - %s, metrics - %s, events - %s, configs - %s' % (
-                len(self.payload['meta']),
-                len(self.payload['metrics']),
-                len(self.payload['events']),
-                len(self.payload['configs'])
-            )
+            f"finished flush_all; new payload stats: "
+            f"meta - {len(self.payload['meta'])}, "
+            f"metrics - {len(self.payload['metrics'])}, "
+            f"events - {len(self.payload['events'])}, "
+            f"configs - {len(self.payload['configs'])}"
         )
 
     def _flush_meta(self):
-        return self._flush(clients=['meta'])
+        return self._flush(clients=["meta"])
 
     def _flush_metrics(self):
-        return self._flush(clients=['metrics'])
+        return self._flush(clients=["metrics"])
 
     def _flush_events(self):
-        return self._flush(clients=['events'])
+        return self._flush(clients=["events"])
 
     def _flush_configs(self):
-        return self._flush(clients=['configs'])
+        return self._flush(clients=["configs"])
 
     def _flush(self, clients=None):
         # get structure
@@ -184,26 +183,26 @@ class Bridge(AbstractManager):
         than object was included in the flush payload and assumes it is non-empty if so."""
         empty = True
         for key in flush_dict.keys():
-            if key != 'object':
+            if key != "object":
                 empty = False
         return empty
 
     def _recursive_object_flush(self, tree, clients=None):
         results = {}
 
-        object_flush = tree['object'].flush(clients=clients)
+        object_flush = tree["object"].flush(clients=clients)
         if object_flush:
             results.update(object_flush)
 
-        if tree['children']:
+        if tree["children"]:
             children_results = []
-            for child_tree in tree['children']:
+            for child_tree in tree["children"]:
                 child_result = self._recursive_object_flush(child_tree, clients=clients)
                 if child_result:
                     children_results.append(child_result)
 
             if children_results:
-                results['children'] = children_results
+                results["children"] = children_results
 
         if not self._empty_flush(results):
             return results
@@ -213,11 +212,31 @@ class Bridge(AbstractManager):
         After payload has been successfully sent, clear the queues (reset them to empty deques).
         """
         self.payload = {
-            'meta': deque(maxlen=360),
-            'metrics': deque(maxlen=360),
-            'events': deque(maxlen=360),
-            'configs': deque(maxlen=360)
+            "meta": deque(maxlen=360),
+            "metrics": deque(maxlen=360),
+            "events": deque(maxlen=360),
+            "configs": deque(maxlen=360),
         }
+
+    def _collapse_metric_backlog_on_timeout(self):
+        """
+        Collapse self.payload['metrics'] to only the most recent snapshot
+        on /update/ ReadTimeout. Returns the number of older snapshots dropped.
+
+        Rationale: a ReadTimeout means the just-attempted POST could not
+        finish within api_timeout. The dominant cause is a backlog of
+        snapshots accumulated during a slow-link or downtime window. The
+        most recent flush is virtually always small (one push_interval of
+        fresh data); keeping just it lets the next cycle proceed instead of
+        repeatedly retrying the same growing batch. meta/events/configs are
+        left alone (small/infrequent by nature).
+        """
+        metrics = self.payload.get("metrics")
+        if not metrics or len(metrics) <= 1:
+            return 0
+        dropped = len(metrics) - 1
+        self.payload["metrics"] = metrics[-1:]
+        return dropped
 
     def _pre_process_payload(self):
         """

--- a/amplify/agent/managers/bridge.py
+++ b/amplify/agent/managers/bridge.py
@@ -1,8 +1,9 @@
 import gc
+import socket
 import time
 
 from collections import deque
-from requests.exceptions import HTTPError, ReadTimeout
+from requests.exceptions import ConnectionError as RequestsConnectionError, HTTPError, ReadTimeout
 
 from amplify.agent.common.context import context
 from amplify.agent.common.cloud import HTTP503Error
@@ -125,12 +126,12 @@ class Bridge(AbstractManager):
                 self.http_delay = 0  # Reset HTTP delay on success
                 context.log.debug("successful update, reset http delay")
         except Exception as e:
-            if isinstance(e, ReadTimeout):
+            if self._is_upload_timeout(e):
                 dropped = self._collapse_metric_backlog_on_timeout()
                 if dropped:
                     context.log.warning(
                         f"bridge_manager dropped {dropped} accumulated metric snapshots after "
-                        f"ReadTimeout (kept most recent); link too slow for backlog"
+                        f"upload timeout (kept most recent); link too slow for backlog"
                     )
             self._post_process_payload()  # Convert lists to deques since send failed
 
@@ -217,6 +218,27 @@ class Bridge(AbstractManager):
             "events": deque(maxlen=360),
             "configs": deque(maxlen=360),
         }
+
+    @staticmethod
+    def _is_upload_timeout(e):
+        """True if the exception signals the just-attempted /update/ POST
+        exceeded its time budget while uploading the request body.
+
+        Catches both the clean client-side ``requests.exceptions.ReadTimeout``
+        and the urllib3-wrapped form that fires when an intermediate proxy
+        (CDN / reverse-proxy) closes the slow connection: that surfaces as
+        ``requests.exceptions.ConnectionError('Connection aborted.',
+        timeout('timed out'))``. Both signals mean the same thing for our
+        purposes: drop the accumulated metric backlog so the next cycle
+        doesn't retry the same too-big payload.
+        """
+        if isinstance(e, ReadTimeout):
+            return True
+        if isinstance(e, RequestsConnectionError):
+            for arg in e.args:
+                if isinstance(arg, (socket.timeout, TimeoutError)):
+                    return True
+        return False
 
     def _collapse_metric_backlog_on_timeout(self):
         """

--- a/tests/test_bridge_collapse_backlog.py
+++ b/tests/test_bridge_collapse_backlog.py
@@ -3,6 +3,10 @@ Tests for Bridge._collapse_metric_backlog_on_timeout — the slow-link
 death-spiral mitigation that drops accumulated metric snapshots when
 a /update/ POST times out.
 """
+import socket
+
+from requests.exceptions import ConnectionError as RequestsConnectionError, HTTPError, ReadTimeout
+
 from amplify.agent.managers.bridge import Bridge
 
 
@@ -37,6 +41,37 @@ def test_collapse_keeps_only_most_recent():
     dropped = b._collapse_metric_backlog_on_timeout()
     assert dropped == 4
     assert b.payload["metrics"] == [snaps[-1]]
+
+
+def test_is_upload_timeout_matches_read_timeout():
+    assert Bridge._is_upload_timeout(ReadTimeout("read timed out"))
+
+
+def test_is_upload_timeout_matches_connection_error_with_socket_timeout():
+    # Real-world shape from urllib3 when a slow upload is cut by an
+    # intermediate proxy (CF / nginx client_body_timeout): the inner
+    # arg is a socket.timeout instance.
+    e = RequestsConnectionError("Connection aborted.", socket.timeout("timed out"))
+    assert Bridge._is_upload_timeout(e)
+
+
+def test_is_upload_timeout_matches_connection_error_with_builtin_timeout():
+    # Python 3.10+ aliases socket.timeout to TimeoutError; guard both.
+    e = RequestsConnectionError("Connection aborted.", TimeoutError("timed out"))
+    assert Bridge._is_upload_timeout(e)
+
+
+def test_is_upload_timeout_rejects_plain_connection_error():
+    # ConnectionError without a timeout inner arg = not an upload timeout
+    # (e.g. RemoteDisconnected for non-time reasons, DNS failure).
+    e = RequestsConnectionError("Connection aborted.", "RemoteDisconnected('foo')")
+    assert not Bridge._is_upload_timeout(e)
+
+
+def test_is_upload_timeout_rejects_http_error():
+    # 5xx etc. go through the existing exponential-backoff path; we must
+    # not conflate them with upload timeouts.
+    assert not Bridge._is_upload_timeout(HTTPError("500"))
 
 
 def test_collapse_preserves_other_buckets():

--- a/tests/test_bridge_collapse_backlog.py
+++ b/tests/test_bridge_collapse_backlog.py
@@ -1,0 +1,52 @@
+"""
+Tests for Bridge._collapse_metric_backlog_on_timeout — the slow-link
+death-spiral mitigation that drops accumulated metric snapshots when
+a /update/ POST times out.
+"""
+from amplify.agent.managers.bridge import Bridge
+
+
+def _bridge_with_payload(metrics_snapshots, events=None, configs=None, meta=None):
+    """Build a Bridge with a synthetic payload (skip __init__'s context deps)."""
+    b = Bridge.__new__(Bridge)
+    b.payload = {
+        "meta": list(meta or []),
+        "metrics": list(metrics_snapshots),
+        "events": list(events or []),
+        "configs": list(configs or []),
+    }
+    return b
+
+
+def test_collapse_no_op_when_empty():
+    b = _bridge_with_payload([])
+    assert b._collapse_metric_backlog_on_timeout() == 0
+    assert b.payload["metrics"] == []
+
+
+def test_collapse_no_op_when_single_snapshot():
+    snap = {"object": {"id": 1}, "metrics": {"a": [1, 2]}}
+    b = _bridge_with_payload([snap])
+    assert b._collapse_metric_backlog_on_timeout() == 0
+    assert b.payload["metrics"] == [snap]
+
+
+def test_collapse_keeps_only_most_recent():
+    snaps = [{"object": {"id": i}, "metrics": {"a": [i]}} for i in range(5)]
+    b = _bridge_with_payload(snaps)
+    dropped = b._collapse_metric_backlog_on_timeout()
+    assert dropped == 4
+    assert b.payload["metrics"] == [snaps[-1]]
+
+
+def test_collapse_preserves_other_buckets():
+    snaps = [{"object": {"id": i}} for i in range(3)]
+    meta = [{"object": {"type": "system"}}]
+    events = [{"event": "x"}, {"event": "y"}]
+    configs = [{"config": "z"}]
+    b = _bridge_with_payload(snaps, events=events, configs=configs, meta=meta)
+    b._collapse_metric_backlog_on_timeout()
+    assert b.payload["meta"] == meta
+    assert b.payload["events"] == events
+    assert b.payload["configs"] == configs
+    assert len(b.payload["metrics"]) == 1


### PR DESCRIPTION
## Problem

On hosts with a slow uplink to the Amplify API (e.g. an instance behind a poor link to the public endpoint sustaining < ~2 KB/s), the agent enters a death spiral:

1. `bridge_manager` accumulates metric snapshots in `self.payload['metrics']` between flushes.
2. The next `/update/` POST tries to ship the accumulated batch (60 s of nginx + plus_status data = 60–100+ KB).
3. The link can't deliver that within `api_timeout` (default 30 s) → `requests.exceptions.ReadTimeout`.
4. `_post_process_payload` re-deques the failed batch.
5. Next cycle, even more snapshots have been appended → next POST is **bigger**.
6. Every subsequent attempt times out. Only the rare cycle that flushes bare `meta` ever succeeds.

Reproduced on a customer host:

```
# Agent log: every /update/ times out at exactly 30 s
2026-05-16 10:18:34 ... payload_size=6116  → 200 OK (heartbeat only)
2026-05-16 10:19:24 ... payload_size=60xxx → ReadTimeout
2026-05-16 10:20:14 ... payload_size=108xxx → ReadTimeout
...
```

The existing `maxlen=360` deque limits guard against unbounded memory but don't fix bandwidth — 360 metric snapshots at one push_interval each = roughly 6 hours of accumulated data, easily megabytes.

## Fix

When `/update/` raises `ReadTimeout` specifically, collapse `self.payload['metrics']` to its most recent snapshot before re-queueing. Rationale: the dominant cause of payload-too-big-for-link timeouts is backlog accumulated during a slow / disconnected window. A single push_interval's fresh flush is virtually always small (one snapshot of current state, not historical). Keeping just the most recent snapshot lets the next cycle proceed instead of perpetually retrying the same growing batch.

- **Healthy hosts: zero behavior change.** No ReadTimeout → helper never runs.
- **Non-timeout errors** (HTTPError 5xx, ConnectionError, etc.) keep the existing exponential-backoff path. We only react on the specific signal that the just-attempted payload was too big for the link.
- **No new config knob.** No proactive cap. Self-heals automatically.
- `meta`/`events`/`configs` buckets are always preserved — they are bounded by their nature (infrequent flush, small per-entry), not by accumulation.
- If the SINGLE most-recent snapshot itself still ReadTimeouts (truly catastrophic link), the agent will keep ReadTimeout-ing, but always shipping fresh-cycle data, never stale backlog. That is the correct upper bound — the bridge can't fix "one cycle of data exceeds what the link can ship in api_timeout".

## Test

`tests/test_bridge_collapse_backlog.py` covers:
- `test_collapse_no_op_when_empty`
- `test_collapse_no_op_when_single_snapshot`
- `test_collapse_keeps_only_most_recent` — N snapshots → 1, returns N-1
- `test_collapse_preserves_other_buckets` — meta/events/configs untouched

## Drive-by

Pre-commit (ruff) on this file flagged pre-existing `UP008` and `UP031` issues in `bridge.py` that I cleaned up while here. Happy to split out if preferred — they are isolated to the same file as the fix.

## Origin

Filed against the GetPageSpeed fork (https://github.com/GetPageSpeed/nginx-amplify-agent) where this bug was diagnosed.